### PR TITLE
⚡ Optimize mission creation to reduce DB round trips

### DIFF
--- a/backend/app/modules/missions/service.py
+++ b/backend/app/modules/missions/service.py
@@ -53,14 +53,18 @@ def create_mission(db: Session, mission: schemas.MissionCreate, campaign_id: int
         prerequisite_id=mission.prerequisite_id
     )
     db.add(db_mission)
-    db.commit()
+    db.flush()
     # Now that the mission has an ID, create the rewards
+    rewards = []
     for reward_in in mission.rewards:
         db_reward = models.MissionReward(
             mission_id=db_mission.id,
             **reward_in.model_dump()
         )
-        db.add(db_reward)
+        rewards.append(db_reward)
+
+    if rewards:
+        db.add_all(rewards)
     db.commit()
     db.refresh(db_mission)
     return db_mission

--- a/backend/tests/benchmark_mission.py
+++ b/backend/tests/benchmark_mission.py
@@ -1,0 +1,71 @@
+import sys
+import os
+import time
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# Add the parent directory to sys.path to allow imports from app
+sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
+
+from app.database import Base
+from app.modules.missions import service as mission_service
+from app.modules.missions import schemas as mission_schemas
+from app.modules.campaigns import models as campaign_models
+
+# Setup in-memory DB
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+def setup_db():
+    Base.metadata.create_all(bind=engine)
+    session = SessionLocal()
+
+    # Create a campaign
+    camp = campaign_models.Campaign(
+        name="Benchmark Campaign",
+        discord_guild_id="bench_guild",
+        dm_role_id="dm",
+        player_role_id="player"
+    )
+    session.add(camp)
+    session.commit()
+    session.refresh(camp)
+    return session, camp.id
+
+def benchmark():
+    session, campaign_id = setup_db()
+
+    # Prepare data
+    num_missions = 100
+    rewards_per_mission = 5
+
+    print(f"Benchmarking creation of {num_missions} missions with {rewards_per_mission} rewards each...")
+
+    start_time = time.time()
+
+    for i in range(num_missions):
+        rewards = []
+        for j in range(rewards_per_mission):
+            rewards.append(mission_schemas.MissionRewardCreate(
+                xp=100,
+                scrip=50
+            ))
+
+        mission_in = mission_schemas.MissionCreate(
+            name=f"Mission {i}",
+            description="Benchmark Mission",
+            status="Available",
+            rewards=rewards
+        )
+
+        mission_service.create_mission(session, mission_in, campaign_id)
+
+    end_time = time.time()
+    total_time = end_time - start_time
+
+    print(f"Total time: {total_time:.4f} seconds")
+    print(f"Avg time per mission: {total_time/num_missions:.4f} seconds")
+
+if __name__ == "__main__":
+    benchmark()


### PR DESCRIPTION
💡 **What:**
Optimized `create_mission` in `backend/app/modules/missions/service.py` to use a single database transaction. 
- Replaced the first `db.commit()` with `db.flush()` to generate the Mission ID.
- Collected all `MissionReward` objects into a list and used `db.add_all()` for batched insertion.
- Executed a single `db.commit()` at the end.

🎯 **Why:**
The previous implementation performed two separate commits and iterated through rewards adding them one by one. This caused:
- Double the transaction overhead (fsync, locking).
- Potential race/atomicity issues (if the second part failed, the mission would exist without rewards).
- Inefficient ORM processing for multiple rewards.

📊 **Measured Improvement:**
A benchmark script was created at `backend/tests/benchmark_mission.py` to measure the creation of 100 missions with 5 rewards each.
*Note:* Due to environment limitations (missing `podman` and `sqlalchemy` dependencies in the restricted shell), the benchmark could not be executed in this environment. However, the theoretical improvement is significant as it reduces N+1 insert round trips to a single batch operation and halves the number of commits.

Rationale for net improvement:
- **Reduced Latency:** Fewer round trips to the database.
- **Atomicity:** Ensures Missions are fully created or not at all.
- **Scalability:** Better handling of missions with many rewards.

---
*PR created automatically by Jules for task [3460128079361794473](https://jules.google.com/task/3460128079361794473) started by @bahaynes*