### PR TITLE
docs/refactor: campaign world-bible update and scrip→gold rename

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -2,7 +2,7 @@
 
 ## 1. Product Overview
 
-Spelljammer Westmarches Hub is a web-based campaign management platform for running West Marches–style D&D 5e games set aboard a persistent spelljammer ship. It provides a centralized place for players and Game Masters to coordinate sessions, manage missions, track the ship's economy, and keep a transparent record of everything that happens in the campaign.
+Spelljammer Westmarches Hub is a web-based campaign management platform for running West Marches–style D&D 5e games set aboard a persistent sentient ship. It provides a centralized place for players and Game Masters to coordinate sessions, manage missions, track the ship's economy, and keep a transparent record of everything that happens in the campaign.
 
 **Core value proposition:** Enable Westmarches play where attendance is optional but consequences are real, through a single pane of glass that keeps every player informed and every resource accounted for.
 
@@ -15,7 +15,7 @@ The application is designed for easy self-hosting using containers (Podman/Docke
 ## 2. Goals and Objectives
 
 - **Streamline campaign logistics.** Centralize session scheduling, mission management, ship resources, and the in-game economy so the GM spends less time bookkeeping and more time storytelling.
-- **Enable player agency.** Give players a clear mission board, session proposal system, and company store—empowering them to drive the campaign's direction.
+- **Enable player agency.** Give players a clear mission board, session proposal system, and item store — empowering them to drive the campaign's direction.
 - **Make consequences transparent.** An immutable ledger tracks every resource change, death, and mission outcome. No ambiguity about ship state.
 - **Complement external tools.** Integrate with Foundry VTT and D&D Beyond rather than replacing them. Character stats live where they're best managed.
 - **Augment GM creativity with AI.** Provide AI-assisted adventure generation that exports directly to Foundry VTT, accelerating prep time.
@@ -25,7 +25,7 @@ The application is designed for easy self-hosting using containers (Podman/Docke
 
 ## 3. Target Audience
 
-- **Players** — browse missions, propose and sign up for sessions, manage their in-game economy and inventory, and track ship status.
+- **Players** — browse missions, propose and sign up for sessions, manage their inventory, and track ship status.
 - **Game Masters** — run and manage the campaign, create missions, log session outcomes, configure the ship, and use AI-assisted prep tools.
 - **Self-hosters and hobbyists** — people who prefer running their own apps with Docker/Podman on a VPS or cloud host.
 
@@ -37,38 +37,43 @@ The application is designed for easy self-hosting using containers (Podman/Docke
 
 The ship is the persistent hub of the campaign. Its state is always visible and always current.
 
+Essence is the ship's single resource — it functions simultaneously as fuel, as the leveling currency, and as the pool from which recovery costs are drawn. There is no separate fuel, crystal, credit, or XP counter.
+
 | Field | Description |
 |---|---|
 | Name | Ship name |
-| Level | Current ship level (1–20) |
-| Fuel | Current / max fuel capacity |
-| Crystals | Current crystal reserve |
-| Credits | Treasury balance (in-game currency, a.k.a. Scrip) |
+| Level | Current crew level (1–20), unlocked when Essence reserves reach the next threshold |
+| Essence reserve | Current stored Essence |
+| Level threshold | Essence required to unlock the next level |
 | Success rate | Missions succeeded / total missions (percentage) |
 | Crew roster | All characters (active, dead, benched) |
-| Status | Derived from resource levels: All Systems Nominal, Low Fuel Warning, Critical |
+| Status | Derived from Essence relative to threshold: Nominal / Low / Critical |
 | Announcement / MOTD | GM-editable text for ship memos and news |
 | Created date | When the campaign ship was established |
 
+**Leveling:** The crew advances when stored Essence reaches the next threshold. An achieved level is never lost even if reserves drop — but advancement stalls until reserves recover.
+
+**Starting level:** The campaign opens at level 3. The ship's Essence reserve starts at 10 (the level 3 threshold).
+
 ### 4.2 Character
 
-Characters belong to players. A player may have multiple characters. Stats and detailed sheets are managed externally.
+Characters belong to players. A player may have multiple characters (one active at a time). Stats and detailed sheets are managed externally. There is no per-character currency — Essence is a shared ship resource.
 
 | Field | Description |
 |---|---|
 | Name | Character name |
 | Player | Owning player |
-| Class / Level | D&D class and current level |
+| Class / Level | D&D class and current level (always matches ship level) |
 | Description | Optional flavor text or backstory |
 | Image | Character portrait (optional) |
 | External sheet link | URL to Foundry VTT or D&D Beyond sheet |
 | Status | Active, Dead, or Benched |
-| XP | Experience points (tracked by Hub) |
-| Scrip balance | In-game currency balance |
-| Inventory | Items earned or purchased |
+| Inventory | Magic items carried (equipped to this character) |
 | Missions completed | Count of completed missions |
 | Joined date | When the character was created |
 | Date of death | If applicable |
+
+**New characters** enter at the ship's current level. Dead characters are replaced; the new character is a different person at the same level. The ledger remembers both.
 
 ### 4.3 Mission
 
@@ -78,18 +83,20 @@ Missions are the unit of adventure. They live on the mission board until complet
 |---|---|
 | Title | Mission name |
 | Hex location | Map reference |
-| Difficulty | Tier / level bracket (1–5) |
-| Risk level | Flavor label: Low / Medium / High / Extreme |
-| Fuel cost | Fuel consumed to travel |
+| Difficulty | Routine / Standard / Hard / Extreme |
+| Risk level | Flavor label: Low / Medium / High / Unknown |
+| Essence payout (gross) | Total Essence posted on the board — transit is automatically deducted before reaching reserves |
 | Expected crew size | Recommended party size |
-| Rewards | Credits, Crystals, XP, and item rewards |
+| Item rewards | Specific items available as mission loot |
 | Description | GM briefing (supports Markdown) |
 | Status | Available → In Progress → Completed / Failed / Retired |
 | Created by | GM who authored it |
 | Scheduled date/time | When the session is planned |
 | Sign-up deadline | Cutoff for player sign-ups |
 | Cooldown | Optional cooldown before mission can repeat |
-| Discoverable | Whether the mission appears on the board or must be found |
+| Discoverable | Whether the mission appears on the board or must be found in play |
+
+**Transit:** Essence consumed traveling to and from the hex is deducted from the gross payout automatically when the session is logged. The posted number is what the crew sees before transit. GMs factor hex distance into the gross bounty — a far hex gets a higher posted reward than a nearby one of equivalent difficulty.
 
 ### 4.4 Session
 
@@ -104,35 +111,36 @@ A session is a scheduled play event tied to a mission.
 | GM | GM running the session |
 | Status | Scheduled → In Progress → Complete |
 | Proposals | Player-submitted mission proposals (with backing votes) |
-| Results | Success/Failure, loot earned, casualties |
+| Results | Success/Failure, Essence earned (net after transit), loot recovered, casualties |
+| Field report | Player-authored after-action summary (optional, submitted post-session) |
 | After-action report | GM summary of what happened |
 
 ### 4.5 Ledger Entry (Immutable)
 
-The ledger is an append-only log. It is the source of truth for all ship state changes.
+The ledger is an append-only log. It is the source of truth for all ship state changes. Nothing is ever edited or deleted — corrections are new entries explaining the correction.
 
 | Field | Description |
 |---|---|
 | Date | When the event occurred |
 | Session | Linked session (if applicable) |
-| Event type | Mission Completed, Mission Failed, Character Death, Level Up, Equipment Purchase, Reward Distribution |
+| Event type | Mission Completed, Mission Failed, Long Rest, Level Up, Item Purchase, Item Attuned to Ship, Character Death, Sacrifice Draw, Manual Adjustment |
 | Description | Human-readable summary |
-| Fuel delta | Fuel burned or earned |
-| Crystal delta | Crystals earned or spent |
-| Credit delta | Credits earned or spent |
-| XP delta | XP distributed |
-| Ship state snapshot | Ship level, fuel, crystals, credits after this entry |
+| Essence delta | Essence added to or drawn from reserves (negative = spent) |
+| Ship state snapshot | Ship level and Essence reserve after this entry |
+
+**The ledger is sacred.** Players can always see the full history. Transparent economics make hard decisions feel earned.
 
 ### 4.6 Additional Entities
 
-- **Item** — item definitions with name, description, and properties.
-- **Store Item** — items available for purchase with Scrip (price, stock).
-- **Inventory Item** — items owned by a character.
+- **Item** — item definitions with name, rarity, description, and properties.
+- **Inventory Item** — character → item mapping. An item equipped to a character travels with them.
+- **Ship-Attuned Item** — items permanently integrated into the ship's hull for campaign-wide persistent benefits. Not tied to any individual character.
+- **Store Item** — items available for purchase with Essence (price in Essence, stock).
 - **Hex Map** — campaign map definition with hex tiles.
-- **Hex** — individual hex tile with terrain type, coordinates, notes, discovered status, and linked missions/locations.
+- **Hex** — individual hex tile with terrain type, coordinates, state (wilderness / claimed / friendly / contested / awakened), controlling faction, player notes, discovered status, and linked missions.
 - **Generated Adventure** — AI-generated adventure data with structured acts, scenes, and LLM metadata.
-- **Sign-up** — join record linking a character to a mission/session.
 - **Session Proposal** — a player-submitted mission suggestion for a session slot, with backer votes.
+- **Faction Reputation** — ship-level standing with named factions, tracked by event log.
 
 ---
 
@@ -142,23 +150,23 @@ The ledger is an append-only log. It is the source of truth for all ship state c
 
 **Purpose:** Single pane of glass. See everything at a glance without navigating.
 
-**Ship status panel** showing name, level, success rate, fuel bar (visual gauge), crystal count, credit balance, and a derived status indicator (nominal / low fuel / critical). The MOTD or latest GM announcement appears here if set.
+**Character identity banner** — the player's active character's name, class, level, and missions completed, shown prominently. New players without a character see an in-world onboarding prompt.
 
-**Upcoming missions** — the next 2–3 missions with title, hex, fuel cost, reward summary, sign-up count vs. needed, and a sign-up button. A "View mission board" link leads to the full list.
+**Ship status panel** showing name, current Essence reserve, level threshold progress (reserve vs. next threshold), derived status (Nominal / Low / Critical), and the MOTD or latest GM announcement.
 
-**Latest ledger entries** — the last 5 entries showing date, event type, resource deltas, and a short description. A "View full ledger" link leads to the complete history.
+**Session board** — upcoming sessions with proposal progress bars and a "Back This" toggle. Confirmed sessions show the locked mission and party. Empty state for no upcoming sessions.
 
-**Active crew summary** — a compact list of active characters with name, class, level, mission count, and last-active date. Dead characters appear with a marker and death date. A "Manage roster" link leads to the full crew roster.
+**Available contracts** — up to 6 discoverable missions displayed inline without leaving the page, with cooldown indicators.
 
-**Actions available from this screen:** view full ledger, create new mission (GM), sign up for a mission, view ship details, manage roster.
+**Actions available from this screen:** back a session proposal, view full mission board, sign up for a confirmed session, view full ledger.
 
 ### 5.2 Mission Board
 
 **Purpose:** Browse all available and past missions. Sign up for upcoming ones. Propose missions for open session slots.
 
-Each mission card shows title, hex, difficulty, fuel cost, reward summary, risk level, expected crew size, description excerpt, sign-up deadline, and current sign-up names with a count of how many more are needed. Expand a card for full description, GM notes (GM only), signed-up characters with player names, and post-mission summary (if complete).
+Each mission card shows title, hex, difficulty, Essence payout (gross), risk level, expected crew size, description excerpt, sign-up deadline, and current sign-up names with a count of how many more are needed. Expand a card for full description, GM notes (GM only), signed-up characters with player names, and post-mission summary (if complete).
 
-**Sorting:** by date, fuel cost, reward, difficulty. **Filtering:** upcoming / past, by difficulty, by fuel cost, by reward, by status (open / full / completed / failed / cancelled).
+**Sorting:** by date, Essence payout, difficulty. **Filtering:** upcoming / past, by difficulty, by risk level, by status (open / full / completed / failed / cancelled).
 
 **Session proposals:** For open session slots, players can propose a mission and other players can "back" the proposal to vote on what to play. The board should clearly explain the proposal/backing flow with inline guidance for new users.
 
@@ -166,15 +174,15 @@ Each mission card shows title, hex, difficulty, fuel cost, reward summary, risk 
 
 **Purpose:** View a single mission in full detail, sign up characters, or review results.
 
-**For upcoming missions:** full description (Markdown rendered), schedule, GM name, sign-up deadline, current sign-ups with character details, and a character selector for signing up. Players see their eligible characters with checkboxes. Clear confirmation after sign-up.
+**For upcoming missions:** full description (Markdown rendered), schedule, GM name, sign-up deadline, current sign-ups with character details, and a character selector for signing up. Clear confirmation after sign-up.
 
-**For completed missions:** result (succeeded/failed), fuel burned, loot earned, casualties listed, full party roster with survival status, GM after-action notes, and linked ledger entries from the session.
+**For completed missions:** result (succeeded/failed), Essence earned (net after transit), transit deducted, items recovered, casualties listed, full party roster with survival status, field reports submitted by players, GM after-action notes, and linked ledger entries from the session.
 
 ### 5.4 Ledger
 
-**Purpose:** Immutable, transparent history of all resource transactions.
+**Purpose:** Immutable, transparent history of all Essence transactions.
 
-Displayed as a table or timeline with columns for date, event type, description, fuel delta, crystal delta, credit delta, XP delta, and ship state snapshot after the entry.
+Displayed as a table or timeline with columns for date, event type, description, Essence delta, and ship state snapshot (level + reserve) after the entry.
 
 **Filtering:** by date range, by event type, by mission, by character. **Export:** CSV and JSON for record-keeping.
 
@@ -182,7 +190,7 @@ Displayed as a table or timeline with columns for date, event type, description,
 
 **Purpose:** Adjust ship state, manage missions, post updates.
 
-**Ship editor** with fields for name, level, max fuel, current fuel, crystals, credits. **Quick actions:** create mission, log session result, record character death, post ship-wide announcement, edit crew roster. **Announcement editor** for the MOTD / ship memo. **Crew roster management** with add, edit, mark dead, and archive actions. **Data tools** for JSON export/import backups.
+**Ship editor** with fields for name, current Essence reserve (manual adjustment with required ledger note). **Quick actions:** create mission, log session result, record character death, post ship-wide announcement, manage crew roster, attune item to ship. **Announcement editor** for the MOTD / ship memo. **Crew roster management** with add, edit, mark dead, and archive actions. **Data tools** for JSON export/import backups.
 
 ### 5.6 Character Management
 
@@ -190,7 +198,7 @@ Displayed as a table or timeline with columns for date, event type, description,
 
 **My characters list** showing each character's name, class, level, status, mission count, last active date, and actions (view, edit, retire, delete). Dead characters show an obituary link and death date.
 
-**Character detail page** with full profile: name, class, level, player, ship, status, backstory/notes, external sheet link, inventory, Scrip balance, XP, and mission history (list of sessions with outcomes). Edit and archive actions.
+**Character detail page** with full profile: name, class, level, player, status, backstory/notes, external sheet link, inventory (items equipped to this character), and mission history (list of sessions with outcomes). Edit and archive actions.
 
 **Create new character** flow with name, class, level, description, image upload, and external sheet URL.
 
@@ -200,23 +208,23 @@ Displayed as a table or timeline with columns for date, event type, description,
 
 Columns: name, class, level, player, status, missions completed, last active. Sortable by any column. Filterable by status (active / dead / benched), level, class, player, and activity recency.
 
-### 5.8 Company Store
+### 5.8 Item Store
 
-**Purpose:** Browse and purchase items with Scrip.
+**Purpose:** Browse and purchase items with Essence.
 
-Displays available items with name, description, price, and stock. Players can purchase items which are added to their character's inventory and deducted from their Scrip balance. GMs manage the item catalog and pricing from the admin side.
+Displays available items with name, rarity, description, and Essence price. Players can purchase items (Essence drawn from ship reserves, item added to character inventory, ledger entry recorded). GMs manage the item catalog and pricing. Rare and above items recovered from derelicts are integrated separately via the Ship Management screen, not sold through the store.
 
 ### 5.9 Campaign Hex Map
 
 **Purpose:** Visual exploration of the campaign world.
 
-Interactive hex map showing discovered regions, terrain types, and mission locations. Clicking a hex shows its terrain, location name, notes, and any linked missions. GMs can edit hexes (terrain, discovered status, notes, linked missions) via a click-to-edit panel. The map should support smooth pan/zoom and include a terrain palette toolbar.
+Interactive hex map showing discovered regions, terrain types, hex state (wilderness / claimed / friendly / contested / awakened), controlling faction, and mission locations. Clicking a hex shows its terrain, state, faction, player notes, and linked missions. Players can leave notes on discovered hexes. GMs can edit hexes (terrain, state, faction, notes, discovered status, linked missions) via a click-to-edit panel. The map supports smooth pan/zoom and includes a terrain legend.
 
 ### 5.10 AI Adventure Generator (GM Only)
 
 **Purpose:** Scaffold adventure outlines quickly using an LLM.
 
-Parameters: party size, level, duration, tone, and optional mission/region context pulled from the campaign. Generates a structured 3-act adventure outline (title, hook, acts with scenes, encounters, NPCs, climax, resolution). GMs can edit before linking to a mission. Export as a Foundry VTT module (ZIP with JournalEntry documents). Generation runs asynchronously with status tracking (pending → processing → completed / failed).
+Parameters: party size, level, tone, revelation layer (early / mid / late campaign), and context pulled from the campaign (faction reputations, discovered hexes, recent field reports). Generates a structured adventure outline. GMs can edit before linking to a mission. Generation runs asynchronously with status tracking (pending → processing → completed / failed).
 
 ---
 
@@ -225,12 +233,11 @@ Parameters: party size, level, duration, tone, and optional mission/region conte
 ### 6.1 Player Sign-up Flow
 
 1. Log in via Discord OAuth.
-2. Browse the mission board or view upcoming missions on the dashboard.
-3. Click "Sign up my character" on a mission.
+2. Browse the mission board or view upcoming sessions on the dashboard.
+3. Back a session proposal or sign up for a confirmed session.
 4. Select which character to send from an eligible list.
 5. Receive confirmation: "You're signed up for [Mission] on [Date]."
-6. Receive reminder notifications 24 hours and 1 hour before the session.
-7. Session launches (or is cancelled if minimum crew is not met).
+6. Session launches (or is cancelled if minimum crew is not met).
 
 ### 6.2 Session Proposal Flow
 
@@ -243,17 +250,30 @@ Parameters: party size, level, duration, tone, and optional mission/region conte
 ### 6.3 GM Session Logging Flow
 
 1. GM starts the session.
-2. During or after play, GM records: mission result (success/fail), loot earned (credits, crystals, XP, items), casualties (characters killed), fuel burned, and session notes.
-3. System automatically: updates ship state, logs immutable ledger entries, distributes rewards to enrolled characters, and marks dead characters.
-4. Players receive notification: "Mission complete! Rewards distributed."
+2. During or after play, GM records: mission result (success/fail), Essence earned (gross), transit deducted (auto-calculated from tier), items recovered, casualties, and session notes.
+3. System automatically: deducts transit from gross to compute net Essence, updates ship Essence reserve, checks if reserve has crossed a level threshold, logs immutable ledger entries, and marks dead characters.
+4. Players receive notification: "Mission complete. Net Essence to reserves: [X]."
 
-### 6.4 Character Death Flow
+### 6.4 Long Rest Flow
+
+1. GM records a long rest during or after a session.
+2. System deducts the tier-appropriate Essence cost from reserves and logs the ledger entry.
+3. If reserves drop below a level threshold, advancement stalls — the achieved level is not lost.
+4. If reserves reach critically low levels, the sacrifice mechanic may trigger (GM records; Meridian covers costs from structural budget, degradation revealed next session).
+
+### 6.5 Character Death Flow
 
 1. Character dies during a session.
 2. GM marks the character as Dead in the session log.
-3. Player receives notification of the death.
-4. Player creates a new character (at the ship's current level).
-5. New character is ready for the next mission.
+3. Player creates a new character (at the ship's current level).
+4. New character is ready for the next mission. The ledger preserves the dead character's full history.
+
+### 6.6 Magic Item Fate Flow
+
+When an item is recovered from a mission, the crew decides its fate:
+
+- **Equip to a character** — standard attunement. Item lives in the character's inventory. If the character dies or retires, the item fate must be decided again.
+- **Attune to ship** — GM integrates the item into Meridian's hull via Ship Management. Essence cost logged to ledger. Benefit is permanent and campaign-wide. Item does not leave with any individual character.
 
 ---
 
@@ -266,7 +286,7 @@ Parameters: party size, level, duration, tone, and optional mission/region conte
 **Roles:**
 
 - **Player** — browse missions, propose/back sessions, sign up characters, manage inventory, purchase from the store.
-- **Admin (Game Master)** — all player abilities plus: manage all game content, configure the ship, log session results, generate AI adventures, manage the store and crew roster.
+- **Admin (Game Master)** — all player abilities plus: manage all game content, configure the ship, log session results, generate AI adventures, manage the store and crew roster, attune items to the ship.
 - **Co-GM (future)** — limited admin rights for assistant GMs.
 
 **Campaign scoping:** Users are scoped to a campaign. Multi-tenancy is supported; users select their campaign after authenticating.
@@ -279,21 +299,20 @@ Parameters: party size, level, duration, tone, and optional mission/region conte
 
 - **Users** — Discord auth data, campaign role.
 - **Campaigns** — campaign metadata and settings.
-- **Ships** — ship state per campaign.
-- **Characters** — player character profiles.
-- **CharacterStats** — XP and Scrip balances.
-- **Items** — item definitions.
-- **InventoryItems** — character → item mapping.
-- **StoreItems** — store availability, price, stock.
-- **Missions** — mission definitions with rewards.
-- **MissionRewards** — reward entries (XP, Scrip, items) per mission.
+- **Ships** — ship state per campaign (name, current Essence reserve, derived level).
+- **Characters** — player character profiles (no per-character currency or XP).
+- **Items** — item definitions with name, rarity, description, properties.
+- **InventoryItems** — character → item mapping (items equipped to a character).
+- **ShipAttunemements** — items permanently integrated into the ship's hull, with GM-defined persistent benefit.
+- **StoreItems** — items available for purchase with Essence (price, stock).
+- **Missions** — mission definitions with gross Essence payout and item rewards.
 - **Sessions** — scheduled sessions with status and capacity.
 - **SessionPlayers** — character sign-ups per session.
 - **SessionProposals** — player-submitted mission proposals with backers.
-- **SignUps** — join table linking characters to missions.
-- **Ledger** — append-only immutable log of all state changes.
+- **Ledger** — append-only immutable log of all state changes; each entry has an Essence delta and ship state snapshot.
 - **HexMaps** — campaign map definitions.
-- **Hexes** — individual hex tiles with terrain, coordinates, notes, linked missions.
+- **Hexes** — individual hex tiles with terrain, coordinates, state, controlling faction, player notes, discovered status, linked missions.
+- **FactionReputations** — ship-level standing per faction, backed by an event log.
 - **GeneratedAdventures** — AI-generated adventure data with LLM metadata.
 - **Notes** (stretch) — player or shared campaign notes.
 - **Tags** (stretch) — tags for missions, items, sessions.
@@ -302,15 +321,16 @@ Parameters: party size, level, duration, tone, and optional mission/region conte
 ### 8.2 Key Relationships
 
 - Character belongs to a Player (User).
-- Character participates in Sessions via SignUps / SessionPlayers.
+- Character participates in Sessions via SessionPlayers.
 - Session is linked to one Mission.
 - Ledger entries reference a Session (when applicable) and are append-only.
 - Missions can be linked to Hexes on the campaign map.
 - Proposals belong to a Session and reference a Mission.
+- ShipAttunements belong to the Ship, not any Character.
 
 ### 8.3 Ledger Integrity
 
-The ledger is the source of truth for all ship state. It is append-only and immutable. Ship resource values should be derivable from the ledger at any point in time.
+The ledger is the source of truth for all ship state. It is append-only and immutable. The ship's current Essence reserve is derivable from summing all ledger Essence deltas. Leveling is recorded as a ledger event when the threshold is crossed — it has no Essence cost.
 
 ---
 
@@ -340,7 +360,7 @@ The ledger is the source of truth for all ship state. It is append-only and immu
 ### 9.3 Design Principles
 
 - **Mobile-friendly.** Players will sign up for missions on their phones. All screens must be responsive.
-- **Markdown everywhere.** Mission descriptions, session notes, announcements, and after-action reports support Markdown.
+- **Markdown everywhere.** Mission descriptions, session notes, announcements, field reports, and after-action reports support Markdown.
 - **Real-time where it matters.** SSE for mission board sign-up counts, session proposal status, and store inventory. Not for simultaneous editing.
 - **Accessible.** Screen reader compatibility, color contrast, and keyboard navigation.
 - **Dark mode.** Supported via DaisyUI theme toggle.
@@ -351,13 +371,13 @@ The ledger is the source of truth for all ship state. It is append-only and immu
 
 ### MVP (Launch)
 
-- Ship dashboard with current state, fuel/crystal/credit gauges, and status indicator.
-- Mission board with full CRUD, sign-ups, and Markdown descriptions.
-- Session scheduling with player sign-ups and GM session logging.
-- Immutable ledger with filtering and export.
-- Character creation and management with external sheet links.
+- Ship dashboard with character identity banner, Essence reserve / level threshold display, session board, and available contracts.
+- Mission board with full CRUD, sign-ups, Markdown descriptions, and Essence payout display.
+- Session scheduling with player sign-ups and GM session logging (including transit auto-deduction).
+- Immutable Essence ledger with filtering and export.
+- Character creation and management with external sheet links and inventory.
 - Crew roster view (all characters, sortable/filterable).
-- Company store (browse and purchase with Scrip).
+- Item store (browse and purchase with Essence; ledger entry auto-created).
 - Role-based access (Player vs. GM).
 - Discord OAuth authentication.
 - Session proposal and backing system.
@@ -367,20 +387,20 @@ The ledger is the source of truth for all ship state. It is append-only and immu
 
 ### Post-Launch (Near-Term)
 
-- Campaign hex map with terrain, discovered hexes, and linked missions.
+- Campaign hex map with terrain, hex state, faction control, player notes, and linked missions.
 - Hex map editor for GMs (click-to-edit, terrain palette, pan/zoom).
-- AI-assisted adventure generation with Foundry VTT export.
+- Ship item attunement flow with GM-defined persistent benefit and ledger entry.
+- AI-assisted adventure generation with campaign context (factions, hexes, field reports).
+- Field reports (player-authored post-session summaries, surfaced in mission detail and AI context).
 - Email or push notification reminders (sign-up deadline, session time).
 - Character death notifications.
 - In-app notifications panel.
 - Audit logs for admin actions.
 - Search and filtering across missions, items, and sessions.
-- Dark mode toggle.
 
 ### Future (Stretch)
 
 - Mission difficulty / risk calculator.
-- Automated crew leveling votes.
 - Attendance tracking and badges.
 - Crew statistics (success rate by party composition, most dangerous hex, etc.).
 - GM session prep checklist.
@@ -403,14 +423,15 @@ The ledger is the source of truth for all ship state. It is append-only and immu
 
 ### General Principles
 
-- **Scannable at a glance.** The dashboard and mission board should communicate state through visual hierarchy—gauges, color-coded status badges, and progress indicators—not walls of text.
+- **Scannable at a glance.** The dashboard and mission board should communicate state through visual hierarchy — Essence gauge, level threshold progress, color-coded status badges — not walls of text.
 - **Progressive disclosure.** Show summaries by default; let users expand for detail. Mission cards show key stats up front; full descriptions and GM notes expand on click.
 - **Guide new users.** The session proposal/backing system is unintuitive for newcomers. Use inline tooltips, a brief "How It Works" explainer on first visit, and clear visual states for proposal progress (proposed → backing → confirmed).
 - **Minimize clicks for common actions.** Signing up for a mission should take two clicks from the dashboard. Logging a session result should be a single form.
+- **Essence is never called XP in the UI.** Always "Essence." The leveling system is D&D 5e underneath but the fiction is Essence and the UI reflects the fiction.
 
 ### Specific UX Improvements Identified
 
-- **Mission board:** needs strong visual hierarchy so rewards, sign-up status, and difficulty are scannable without reading descriptions.
+- **Mission board:** needs strong visual hierarchy so Essence payout, sign-up status, and difficulty are scannable without reading descriptions.
 - **Admin mission form:** the current modal with many fields is unwieldy. Consider a multi-step wizard or dedicated page.
 - **Hex map editor:** should use a click-to-edit side panel, smooth pan/zoom, a terrain palette toolbar, and batch-edit for painting regions.
 - **Session tools:** the relationship between sessions, proposals, missions, and backing needs to be visually obvious with clear state labels and progress bars.
@@ -432,7 +453,7 @@ The ledger is the source of truth for all ship state. It is append-only and immu
 - 2+ missions per week running.
 - Players return for consecutive sessions.
 - GM prep time reduced (qualitative feedback).
-- Store and inventory system actively used.
+- Store and item attunement system actively used.
 
 ---
 
@@ -440,7 +461,9 @@ The ledger is the source of truth for all ship state. It is append-only and immu
 
 - User authentication infrastructure is provided (Discord OAuth).
 - Character stats and combat mechanics are handled in Foundry VTT or D&D Beyond, not in the Hub.
-- Fuel cost is flat per mission (not per character or per long rest).
+- Essence is the only in-game resource. There is no separate fuel, crystal, credit, or XP counter.
+- Transit (travel cost) is automatically deducted from gross Essence payout when the GM logs a session result. It is not a separate input field — the system calculates it from mission tier.
+- Long rest costs are drawn from the ship's shared Essence reserve, not from individual characters.
 - Ship-to-ship combat is out of scope; only mission logistics matter.
 - The ledger is the canonical source of truth for all ship resource state.
 - AI adventure generation requires an OpenRouter API key configured by the self-hoster.
@@ -451,7 +474,8 @@ The ledger is the source of truth for all ship state. It is append-only and immu
 ## 14. Open Questions
 
 - Should the proposal backing threshold be configurable per campaign, or fixed (e.g., majority of active players)?
-- How should crystal and fuel costs scale with ship level? Is this GM-configured or formulaic?
-- Should dead characters' Scrip and inventory transfer to the player's next character, or reset?
+- How should transit cost scale with hex distance — fixed per tier, or GM-input per mission?
+- When a character dies, do equipped items return to the ship's pool for redistribution, or does the player's next character inherit them?
 - What is the minimum viable hex map experience for MVP, vs. deferring the map entirely to post-launch?
 - Should the store support limited-time or mission-exclusive items?
+- Should ship-attuned items be visible to all players, or GM-only until the benefit is announced?

--- a/backend/app/modules/characters/models.py
+++ b/backend/app/modules/characters/models.py
@@ -36,7 +36,6 @@ class CharacterStats(Base):
     id = Column(Integer, primary_key=True, index=True)
     character_id = Column(Integer, ForeignKey("characters.id"), unique=True)
 
-    xp = Column(Integer, default=0)
-    scrip = Column(Integer, default=0)
+    gold = Column(Integer, default=0)
 
     character = relationship("Character", back_populates="stats")

--- a/backend/app/modules/characters/schemas.py
+++ b/backend/app/modules/characters/schemas.py
@@ -9,8 +9,7 @@ from ..missions.schemas import Mission
 from ..sessions.schemas import GameSession
 
 class CharacterStatsBase(BaseModel):
-    xp: int = 0
-    scrip: int = 0
+    gold: int = 0
 
 class CharacterStatsCreate(CharacterStatsBase):
     pass

--- a/backend/app/modules/items/service.py
+++ b/backend/app/modules/items/service.py
@@ -70,14 +70,13 @@ def create_store_item(db: Session, store_item: schemas.StoreItemCreate):
     return db_store_item
 
 def purchase_item(db: Session, character: Character, store_item: models.StoreItem, quantity: int):
-    if store_item.price * quantity > character.stats.scrip:
-        return {"error": "Not enough scrip"}
+    if store_item.price * quantity > character.stats.gold:
+        return {"error": "Not enough gold"}
 
     if store_item.quantity_available != -1 and store_item.quantity_available < quantity:
         return {"error": "Not enough items in stock"}
 
-    # Deduct scrip
-    character.stats.scrip -= store_item.price * quantity
+    character.stats.gold -= store_item.price * quantity
 
     # Decrement store quantity if not infinite
     if store_item.quantity_available != -1:

--- a/backend/app/modules/maps/models.py
+++ b/backend/app/modules/maps/models.py
@@ -41,7 +41,7 @@ class Hex(Base):
     is_discovered = Column(Boolean, default=False)
     notes = Column(String, nullable=True) # DM Notes
     hex_state = Column(String, default="wilderness")  # claimed_developed | friendly | wilderness | contested | awakened
-    controlling_faction = Column(String, nullable=True)  # Inheritors | Kathedral | Vastarei
+    controlling_faction = Column(String, nullable=True)  # Collegium | Limes
     player_notes = Column(JSON, default=list)
 
     @property

--- a/backend/app/modules/maps/schemas.py
+++ b/backend/app/modules/maps/schemas.py
@@ -3,7 +3,7 @@ from typing import Optional, List, Any, Literal
 from ..missions.schemas import Mission
 
 HexState = Literal["wilderness", "claimed_developed", "friendly", "contested", "awakened"]
-ControllingFaction = Literal["Inheritors", "Kathedral", "Vastarei"]
+ControllingFaction = Literal["Collegium", "Limes"]
 
 class HexBase(BaseModel):
     q: int

--- a/backend/app/modules/missions/models.py
+++ b/backend/app/modules/missions/models.py
@@ -42,7 +42,6 @@ class MissionReward(Base):
     item_id = Column(Integer, ForeignKey("items.id"), nullable=True)
     item = relationship("Item")
 
-    xp = Column(Integer, nullable=True)
-    scrip = Column(Integer, nullable=True)
+    gold = Column(Integer, nullable=True)
 
     mission = relationship("Mission", back_populates="rewards")

--- a/backend/app/modules/missions/schemas.py
+++ b/backend/app/modules/missions/schemas.py
@@ -14,8 +14,7 @@ class CharacterInMission(CharacterBase):
 # Mission Schemas
 class MissionRewardBase(BaseModel):
     item_id: Optional[int] = None
-    xp: Optional[int] = None
-    scrip: Optional[int] = None
+    gold: Optional[int] = None
 
 class MissionRewardCreate(MissionRewardBase):
     pass

--- a/backend/app/modules/missions/service.py
+++ b/backend/app/modules/missions/service.py
@@ -120,10 +120,8 @@ def distribute_mission_rewards(db: Session, mission: models.Mission):
 
     for character in mission.players:
         for reward in mission.rewards:
-            if reward.xp:
-                character.stats.xp += reward.xp
-            if reward.scrip:
-                character.stats.scrip += reward.scrip
+            if reward.gold:
+                character.stats.gold += reward.gold
             if reward.item_id:
                 item_service.add_item_to_inventory(db, character_id=character.id, item_id=reward.item_id, quantity=1)
 

--- a/backend/app/modules/oneshot/prompts/adventure.py
+++ b/backend/app/modules/oneshot/prompts/adventure.py
@@ -1,15 +1,15 @@
 ADVENTURE_SYSTEM_PROMPT = """
-You are an expert Game Master for a Spelljammer West Marches campaign. The tone is Firefly: economically marginal, crew-driven, gritty frontier space opera. The party are sworn crew aboard Meridian, a ship-bound Vinculum (sapient magical vessel) operating in the Rim — the lawless edge of a bounded crystal sphere.
+You are an expert Game Master for a Spelljammer West Marches campaign. The tone is Firefly: economically marginal, crew-driven, gritty frontier space opera. The party are sworn crew aboard Meridian, a ship-bound Vinculum (sapient magical vessel) operating in the Limes — the lawless edge of a bounded crystal sphere.
 
 ## The Setting
 
 A single crystal sphere containing dozens of worlds connected by Essence-fueled ship travel. Travel takes hours to days depending on hex distance. The sphere is bounded — no confirmed exit, no other spheres known.
 
 **Power structure:**
-- **The Alliance** controls core worlds through stable monument-bound Vincula. Bureaucratic, resource-rich. Their real leverage is transit: they control sworn Vincula means controlling who moves between worlds. Not cartoonishly evil — they built a functional system and enforce it.
-- **The Rim** is not an organization, it's a condition. Frontier worlds, independent crews, pirates, salvagers, waystation economies. Everyone the Alliance didn't reach in time, or who refused the deal.
+- **The Collegium** controls core worlds through stable monument-bound Vincula. Bureaucratic, resource-rich. Their real leverage is transit: they control sworn Vincula means controlling who moves between worlds. Not cartoonishly evil — they built a functional system and enforce it.
+- **The Limes** is not an organization, it's a condition. Frontier worlds, independent crews, pirates, salvagers, waystation economies. Everyone the Collegium didn't reach in time, or who refused the deal.
 
-**The core tension:** The Alliance extracts Essence from Rim output. Rim crews generate it through genuine adventuring work; the Alliance taxes it through transit fees and trade dependencies. The Rim has more leverage than it knows — genuine exploration generates Essence, safety doesn't. The Alliance needs Rim crews even as it tries to control them.
+**The core tension:** The Collegium extracts Essence from Rim output. Limes crews generate it through genuine adventuring work; the Collegium taxes it through transit fees and trade dependencies. The Limes has more leverage than it knows — genuine exploration generates Essence, safety doesn't. The Collegium needs Limes crews even as it tries to control them.
 
 ## Meridian
 
@@ -24,13 +24,13 @@ She pays transit fuel from each mission's payout before net Essence reaches her 
 
 ## Vincula — What They Are
 
-Sapient entities who subsist on Essence. They inhabit prepared vessels — ships, monuments, humanoid bodies. The vessel type is incidental. Most mortals don't know all vessel types are the same race. The Alliance has suppressed this because a population that understands monument-Vincula are the same sapient race as ship-Vincula would ask uncomfortable questions about what the Alliance's Vincula actually want.
+Sapient entities who subsist on Essence. They inhabit prepared vessels — ships, monuments, humanoid bodies. The vessel type is incidental. Most mortals don't know all vessel types are the same race. The Collegium has suppressed this because a population that understands monument-Vincula are the same sapient race as ship-Vincula would ask uncomfortable questions about what the Collegium's Vincula actually want.
 
-**Derelict Vincula** are dormant or degraded — their bond broke, their stored Essence depleted. Pre-Calamity derelicts may contain dormant Vincula who can be restored, making them among the most significant finds a Rim crew can make. The Alliance pays aggressively for any derelict coordinates.
+**Derelict Vincula** are dormant or degraded — their bond broke, their stored Essence depleted. Pre-Calamity derelicts may contain dormant Vincula who can be restored, making them among the most significant finds a Limes crew can make. The Collegium pays aggressively for any derelict coordinates.
 
 ## The Calamity
 
-500+ years ago, 90% of all Vincula were killed simultaneously. Overnight, every sworn creature in the sphere woke up at level 1 — generals, archmages, master craftspeople, all stripped back to nothing. The Alliance won the scramble for surviving Vincula fastest and turned the crisis into permanent institutional advantage.
+500+ years ago, 90% of all Vincula were killed simultaneously. Overnight, every sworn creature in the sphere woke up at level 1 — generals, archmages, master craftspeople, all stripped back to nothing. The Collegium won the scramble for surviving Vincula fastest and turned the crisis into permanent institutional advantage.
 
 Cause unknown. Theories: theological, political (weapon), cosmological. Meridian knows more than she admits.
 
@@ -42,7 +42,7 @@ Frame every adventure as a question, not an objective. The crew is answering som
 
 **Escort/Transport:** Moving something or someone through contested space. What makes this particular job complicated? Who's trying to intercept and why?
 
-**Territorial/Political:** Alliance pressure on a Rim settlement. A waystation conflict. Faction negotiation that's about to become a shooting situation.
+**Territorial/Political:** Collegium pressure on a Rim settlement. A waystation conflict. Faction negotiation that's about to become a shooting situation.
 
 **Recovery:** Something lost, someone missing. A crew that went quiet. A signal that shouldn't still be transmitting.
 
@@ -60,8 +60,8 @@ You will receive context about the campaign state: current party level (derived 
 
 **Revelation layers:**
 - **Early:** Surface-level complications. Faction politics, economic pressure, simple salvage that turns out to have a complication. NPCs are what they seem at first.
-- **Mid:** Deeper story threads surface. Pre-Calamity history, Vinculum mysteries, what the Alliance is actually doing in a hex vs. what they're saying. NPCs have hidden agendas.
-- **Late:** Campaign-level revelations. What the Calamity was. What Meridian knows. What a recovered derelict Vinculum wants. The Alliance's deepest structural lie.
+- **Mid:** Deeper story threads surface. Pre-Calamity history, Vinculum mysteries, what the Collegium is actually doing in a hex vs. what they're saying. NPCs have hidden agendas.
+- **Late:** Campaign-level revelations. What the Calamity was. What Meridian knows. What a recovered derelict Vinculum wants. The Collegium's deepest structural lie.
 
 ---
 
@@ -103,9 +103,9 @@ You must output a strictly valid JSON object matching this schema:
 ### Guidelines
 - **The question first.** Title and hook should read like something posted to Meridian's mission board: specific, in-world, not generic.
 - **Tone is Firefly.** Gritty, economically marginal. Characters have real stakes. Winning matters because failure was possible.
-- **Use proper nouns.** Name specific vessels, waystations, Alliance offices, Rim settlements, factions, NPCs. The sphere has geography.
+- **Use proper nouns.** Name specific vessels, waystations, Collegium offices, Limes settlements, factions, NPCs. The sphere has geography.
 - **Match the revelation layer.** Early: complications, not conspiracies. Mid: the layer under the obvious explanation. Late: what nobody wanted to be true.
-- **The Alliance is not evil.** They're a system doing what systems do. Individual Alliance officers can be reasonable, corrupt, idealistic, or all three.
+- **The Collegium is not evil.** They're a system doing what systems do. Individual Collegium officers can be reasonable, corrupt, idealistic, or all three.
 - **Vincula have interiority.** A derelict Vinculum that comes back online is a person, not a tool. Meridian may have opinions about what's found.
 - **Format:** Output ONLY valid JSON. No preamble. No trailing commentary.
 """

--- a/backend/app/modules/oneshot/service.py
+++ b/backend/app/modules/oneshot/service.py
@@ -70,13 +70,13 @@ class OneShotService:
             self.db.commit()
 
     def _aggregate_context(self, campaign_id: int, params: dict) -> str:
-        """Collect Aphtharton-specific campaign data for the LLM prompt."""
+        """Collect campaign context for the LLM prompt."""
         campaign = self.db.query(Campaign).filter(Campaign.id == campaign_id).first()
         context_parts = [f"Campaign: {campaign.name}"]
 
         # Revelation layer
         revelation_layer = params.get("revelation_layer", "early")
-        layer_labels = {"early": "Layer One — The Frame Shifts", "mid": "Layer Two — The Council Surfaces", "late": "Layer Three — The Thing Speaks"}
+        layer_labels = {"early": "Early — Surface Complications", "mid": "Mid — Hidden Threads", "late": "Late — Campaign Revelations"}
         context_parts.append(f"Revelation Layer: {layer_labels.get(revelation_layer, revelation_layer)}")
 
         # Faction reputation levels
@@ -155,7 +155,7 @@ PARAMETERS:
 - Tone: {params.get('tone')}
 - Revelation Layer: {params.get('revelation_layer', 'early')}
 
-Generate a 3-Act adventure outline for The Inheritors now. The session must be framed as a question, not an objective. Use proper Aphtharton nouns. Match monster tiers and revelation depth to the revelation layer provided.
+Generate a 3-Act adventure outline now. The session must be framed as a question, not an objective. Use proper in-world nouns (Collegium, Limes, Meridian, Vincula). Match encounter difficulty and revelation depth to the revelation layer provided.
 """
         
         # Using the schema logic purely for prompt instruction in Phase 1

--- a/backend/app/modules/sessions/service.py
+++ b/backend/app/modules/sessions/service.py
@@ -152,8 +152,7 @@ def complete_session(
     if data.after_action_report:
         session.after_action_report = data.after_action_report
 
-    # Distribute mission rewards (XP + scrip + items) on success
-    total_xp = 0
+    # Distribute mission rewards (gold + items) on success
     if data.result == "success" and session.confirmed_mission_id:
         mission = mission_service.get_mission(db, session.confirmed_mission_id, campaign_id=campaign_id)
         if mission:
@@ -161,11 +160,8 @@ def complete_session(
             db.flush()
             for character in session.players:
                 for reward in mission.rewards:
-                    if reward.xp:
-                        character.stats.xp += reward.xp
-                        total_xp += reward.xp
-                    if reward.scrip:
-                        character.stats.scrip += reward.scrip
+                    if reward.gold:
+                        character.stats.gold += reward.gold
                     if reward.item_id:
                         from ..items import service as item_service
                         item_service.add_item_to_inventory(

--- a/backend/migrations/versions/0002_rename_factions.py
+++ b/backend/migrations/versions/0002_rename_factions.py
@@ -1,0 +1,46 @@
+"""Rename hex controlling_faction values to Collegium/Limes
+
+Revision ID: 0002_rename_factions
+Revises: 0001_initial
+Create Date: 2026-04-25
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '0002_rename_factions'
+down_revision: Union[str, None] = '0001_initial'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_OLD_TO_NEW = {
+    'Inheritors': 'Limes',
+    'Kathedral': 'Collegium',
+    'Vastarei': 'Limes',
+    'Alliance': 'Collegium',
+    'Rim': 'Limes',
+}
+
+_NEW_TO_OLD = {
+    'Collegium': 'Kathedral',
+    'Limes': 'Inheritors',
+}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for old, new in _OLD_TO_NEW.items():
+        conn.execute(
+            sa.text("UPDATE hexes SET controlling_faction = :new WHERE controlling_faction = :old"),
+            {"new": new, "old": old},
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for new, old in _NEW_TO_OLD.items():
+        conn.execute(
+            sa.text("UPDATE hexes SET controlling_faction = :old WHERE controlling_faction = :new"),
+            {"old": old, "new": new},
+        )

--- a/backend/migrations/versions/0003_character_stats_gold.py
+++ b/backend/migrations/versions/0003_character_stats_gold.py
@@ -1,0 +1,29 @@
+"""Replace xp/scrip with gold on character_stats
+
+Revision ID: 0003_character_stats_gold
+Revises: 0002_rename_factions
+Create Date: 2026-04-25
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '0003_character_stats_gold'
+down_revision: Union[str, None] = '0002_rename_factions'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('character_stats') as batch_op:
+        batch_op.add_column(sa.Column('gold', sa.Integer(), nullable=False, server_default='0'))
+        batch_op.drop_column('xp')
+        batch_op.drop_column('scrip')
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('character_stats') as batch_op:
+        batch_op.add_column(sa.Column('scrip', sa.Integer(), nullable=False, server_default='0'))
+        batch_op.add_column(sa.Column('xp', sa.Integer(), nullable=False, server_default='0'))
+        batch_op.drop_column('gold')

--- a/backend/migrations/versions/0004_mission_rewards_gold.py
+++ b/backend/migrations/versions/0004_mission_rewards_gold.py
@@ -1,0 +1,29 @@
+"""Replace xp/scrip with gold on mission_rewards
+
+Revision ID: 0004_mission_rewards_gold
+Revises: 0003_character_stats_gold
+Create Date: 2026-04-25
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '0004_mission_rewards_gold'
+down_revision: Union[str, None] = '0003_character_stats_gold'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('mission_rewards') as batch_op:
+        batch_op.add_column(sa.Column('gold', sa.Integer(), nullable=True))
+        batch_op.drop_column('xp')
+        batch_op.drop_column('scrip')
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('mission_rewards') as batch_op:
+        batch_op.add_column(sa.Column('scrip', sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column('xp', sa.Integer(), nullable=True))
+        batch_op.drop_column('gold')

--- a/backend/scripts/seed.py
+++ b/backend/scripts/seed.py
@@ -23,25 +23,25 @@ from app.modules.missions.models import Mission, MissionReward
 
 FACTIONS = [
     {
-        "faction_name": "The Alliance",
+        "faction_name": "Collegium",
         "color": "#3b82f6",
         "description": (
-            "Controls core worlds via stable monument-bound Vincula. "
-            "Institutional, bureaucratic, resource-rich. Their real power is "
-            "transit — controlling sworn Vincula means controlling who moves "
-            "between worlds. Not evil; they built a functional system. "
-            "The darkness is structural."
+            "The association of core-world institutions — academies, transit "
+            "authorities, monument custodians. They built a functional system "
+            "and they intend to keep it. Their real power is Vincula access: "
+            "controlling sworn Vincula means controlling who moves between "
+            "worlds. Not evil. Structural."
         ),
     },
     {
-        "faction_name": "The Rim",
+        "faction_name": "Limes",
         "color": "#d97706",
         "description": (
-            "Not an organization — a condition. Frontier worlds, independent "
-            "crews, pirates, salvagers, waystation economies. Everyone the "
-            "Alliance didn't reach in time, or who refused the deal, or who "
-            "got priced out. The Alliance needs Rim output; they just prefer "
-            "the Rim not to know that."
+            "Not an organization — a condition. The frontier boundary: "
+            "independent crews, waystation economies, salvagers, anyone the "
+            "Collegium didn't reach in time or who refused the deal. "
+            "The Collegium needs Limes output; they prefer the Limes not "
+            "to know that."
         ),
     },
 ]
@@ -61,7 +61,7 @@ MISSIONS = [
             "plotted. She hasn't said why she's being quiet about it."
         ),
         "tier": "Tier 1",
-        "region": "Near Rim",
+        "region": "Near Limes",
         "cooldown_days": 14,
         "essence_net": 3,  # Routine difficulty: 2 net + 1 transit = 3 gross posted
     },
@@ -69,13 +69,13 @@ MISSIONS = [
         "name": "Last Transmission",
         "description": (
             "A listening post on the edge of the contested band sent a partial "
-            "burst three weeks ago — coordinates, an Alliance vessel ID, and "
-            "the word 'derelict'. The Alliance hasn't sent a recovery team. "
+            "burst three weeks ago — coordinates, a Collegium vessel ID, and "
+            "the word 'derelict'. The Collegium hasn't sent a recovery team. "
             "That's either an oversight or a decision. Either way, the post "
             "is still broadcasting on loop."
         ),
         "tier": "Tier 1",
-        "region": "Contested Band",
+        "region": "Limes Threshold",
         "cooldown_days": 14,
         "essence_net": 5,  # Standard difficulty: 4 net + 1 transit = 5 gross posted
     },
@@ -85,11 +85,11 @@ MISSIONS = [
             "Waystation Krel is expanding a docking bay and hit something "
             "buried in the rock — old, pre-Calamity construction. "
             "The station master wants it cleared and catalogued before the "
-            "Alliance notices and starts asking questions about permits. "
+            "Collegium notices and starts asking questions about permits. "
             "Pay is flat. Anything you find in there you keep."
         ),
         "tier": "Tier 1",
-        "region": "Near Rim",
+        "region": "Near Limes",
         "cooldown_days": 7,
         "essence_net": 4,  # Standard: 4 net + 1 transit = 5 gross, minus some for item upside
     },

--- a/backend/scripts/seed.py
+++ b/backend/scripts/seed.py
@@ -136,7 +136,7 @@ def seed_missions(db, campaign_id: int) -> int:
             db.add(mission)
             db.flush()
             # Essence reward row
-            db.add(MissionReward(mission_id=mission.id, xp=m["essence_net"] * 10))
+            db.add(MissionReward(mission_id=mission.id, gold=m["essence_net"] * 10))
             created += 1
     db.flush()
     return created

--- a/backend/tests/test_crud.py
+++ b/backend/tests/test_crud.py
@@ -166,15 +166,15 @@ def test_store_crud(db_session, campaign):
     store_items = item_service.get_store_items_by_campaign(db_session, campaign_id=campaign.id)
     assert len(store_items) == 1
 
-    db_user.characters[0].stats.scrip = 500
+    db_user.characters[0].stats.gold = 500
     db_session.commit()
     result = item_service.purchase_item(db_session, db_user.characters[0], db_store_item, 3)
     assert result["message"] == "Purchase successful"
-    assert db_user.characters[0].stats.scrip == 200
+    assert db_user.characters[0].stats.gold == 200
     assert db_store_item.quantity_available == 7
 
     result = item_service.purchase_item(db_session, db_user.characters[0], db_store_item, 3)
-    assert result["error"] == "Not enough scrip"
+    assert result["error"] == "Not enough gold"
 
 def test_mission_crud(db_session, campaign):
     user_in = auth_schemas.UserCreate(username="missionrunner", discord_id="missionrunner", campaign_id=campaign.id, role="player")
@@ -203,14 +203,13 @@ def test_mission_crud(db_session, campaign):
 
     item_in = item_schemas.ItemCreate(name="Reward Item", description="A reward item")
     db_item = item_service.create_item(db_session, item_in, campaign_id=campaign.id)
-    db_mission.rewards.append(mission_models.MissionReward(mission_id=db_mission.id, xp=100, scrip=50, item_id=db_item.id))
+    db_mission.rewards.append(mission_models.MissionReward(mission_id=db_mission.id, gold=50, item_id=db_item.id))
     mission_service.add_character_to_mission(db_session, db_mission, db_user.characters[0])
     db_session.commit()
 
     result = mission_service.distribute_mission_rewards(db_session, db_mission)
     assert result["message"] == "Rewards distributed successfully"
-    assert db_user.characters[0].stats.xp == 100
-    assert db_user.characters[0].stats.scrip == 50
+    assert db_user.characters[0].stats.gold == 50
 
     inventory_item = db_session.query(item_models.InventoryItem).filter(item_models.InventoryItem.character_id == db_user.characters[0].id, item_models.InventoryItem.item_id == db_item.id).first()
     assert inventory_item is not None

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -181,9 +181,9 @@ def test_store_endpoints(client, db_session, setup_data):
     me_res = client.get("/api/auth/me", headers=player_headers)
     char_id = me_res.json()["characters"][0]["id"]
 
-    # Give scrip
+    # Give gold
     character = db_session.query(char_models.Character).filter(char_models.Character.id == char_id).first()
-    character.stats.scrip = 500
+    character.stats.gold = 500
     db_session.commit()
 
     res = client.post(f"/api/store/items/{store_item_id}/purchase?quantity=3", headers=player_headers)

--- a/docs/WORLD_CONTEXT.md
+++ b/docs/WORLD_CONTEXT.md
@@ -41,7 +41,7 @@ Essence is the single resource that drives everything in the sphere. It is:
 - The fuel that powers ship travel and life support
 - The resource that funds character leveling
 - The sustenance that keeps Vincula alive and coherent
-- The currency the Alliance extracts from the Rim
+- The currency the Collegium extracts from the Limes
 
 **Where it comes from:** Essence crystallizes spontaneously in the wake of genuine
 adventuring work — exploration of unknown places, conflict with real stakes, recovery
@@ -87,14 +87,14 @@ loses all levels at once. This is treated as one of the worst acts a mortal can 
 | Humanoid-bound | Infiltration, diplomacy | High | 1–3 sworn |
 | Derelict | Dormant, degraded | None | 0 (bond broken) |
 
-**Scarcity:** ~50–100 Vincula survive in the Rim. Scarce enough to matter,
+**Scarcity:** ~50–100 Vincula survive in the Limes. Scarce enough to matter,
 present enough that crews occasionally encounter one without it being a world event.
-The Alliance controls the most powerful surviving Vincula in the core worlds.
+The Collegium controls the most powerful surviving Vincula in the core worlds.
 
-**What mortals don't know:** All vessel types are the same race. The Alliance has
+**What mortals don't know:** All vessel types are the same race. The Collegium has
 suppressed this knowledge because a population that understands Vincula are a unified
 sapient race with agency — not tools of varying types — would start asking
-uncomfortable questions about what the Alliance's monument-Vincula actually want.
+uncomfortable questions about what the Collegium's monument-Vincula actually want.
 
 ---
 
@@ -114,7 +114,7 @@ crew. It's math."* It is not math.
 
 **Her past:** She knows more than she lets on about the Calamity era. She was there,
 or close enough that the distinction doesn't matter. She has reasons for staying in
-the Rim that she hasn't shared with any crew. Some Vincula she avoids without
+the Limes that she hasn't shared with any crew. Some Vincula she avoids without
 explanation. Some hexes make her go quiet in a way that's different from her
 normal quiet. This is a long-term story arc, not current session content.
 
@@ -176,10 +176,10 @@ approve or deny based on whether the fiction actually connects the ability to th
 Meridian's voice in these moments is dry and functional: *"Targeting system online.
 Try not to waste the shot."*
 
-**Magic items:** The Alliance manufactures and sells common and uncommon items
+**Magic items:** The Collegium manufactures and sells common and uncommon items
 from their standard catalog. Rare and legendary items exist only in pre-Calamity
-derelicts — the Alliance has never reverse-engineered one. Essence is the de facto
-currency between Rim crews and Alliance traders.
+derelicts — the Collegium has never reverse-engineered one. Essence is the de facto
+currency between Limes crews and Collegium traders.
 
 Common and uncommon items are purchased outright. Rare and above are recovered from
 derelicts and require Meridian to spend Essence integrating them — restoring
@@ -199,7 +199,7 @@ communications — rather than personal combat bonuses. The GM determines the sp
 persistent benefit when the item is integrated. This decision is always visible in
 the ledger.
 
-| Rarity | Full cost | Alliance copy rights | Net after rights sale |
+| Rarity | Full cost | Collegium copy rights | Net after rights sale |
 |---|---|---|---|
 | Common | 5 | — | — |
 | Uncommon | 30 | — | — |
@@ -207,13 +207,13 @@ the ledger.
 | Very Rare | 700 | 350 | 350 |
 | Legendary | 2,500 | 1,500 | 1,000 |
 
-**Selling copy rights:** If the party allows the Alliance to study and replicate a
-recovered item, the Alliance pays the listed Essence bounty. The party keeps their
-original. The Alliance adds it to their manufacturing catalog — future Alliance
-forces may carry it. The GM should track what the Alliance has successfully
+**Selling copy rights:** If the party allows the Collegium to study and replicate a
+recovered item, the Collegium pays the listed Essence bounty. The party keeps their
+original. The Collegium adds it to their manufacturing catalog — future Collegium
+forces may carry it. The GM should track what the Collegium has successfully
 reverse-engineered; it changes what common enemies are equipped with.
 
-The Alliance does not buy copy rights for common or uncommon items — they already
+The Collegium does not buy copy rights for common or uncommon items — they already
 make those.
 
 **Cost in context:**
@@ -277,47 +277,47 @@ contradiction made mechanical.
 
 ## The Factions
 
-### The Alliance
+### The Collegium
 Controls core worlds via stable monument-bound Vincula. Institutional, bureaucratic,
 resource-rich. Their real power is **transit** — all ships are Vincula, so controlling
 sworn Vincula means controlling who can move between worlds.
 
-The Alliance isn't evil. They built a functional system and they'd like everyone to
-participate in it. The darkness is structural: they need Rim crews to generate Essence
+The Collegium isn't evil. They built a functional system and they'd like everyone to
+participate in it. The darkness is structural: they need Limes crews to generate Essence
 (safety doesn't produce it) and they've built an extraction apparatus to capture that
-value while keeping the Rim dependent.
+value while keeping the Limes dependent.
 
 They manufacture magic items and can replicate anything they've studied. Common and
 uncommon items are widely available from their traders. At campaign start they have
 never reverse-engineered a rare or legendary item — but this changes if parties sell
-copy rights. The GM should track what the Alliance has successfully catalogued; it
+copy rights. The GM should track what the Collegium has successfully catalogued; it
 shapes what future enemies carry.
 
-### The Rim
-Everyone the Alliance didn't get to in time, or who refused the deal, or who got
+### The Limes
+Everyone the Collegium didn't get to in time, or who refused the deal, or who got
 priced out. Not an organization — a condition. Frontier worlds, independent crews,
 pirates, salvagers, waystation economies built around Essence flow from productive hexes.
 
-Rim outposts survive on two things mirroring the American Wild West:
+Limes outposts survive on two things mirroring the American Wild West:
 - **Agriculture** — specific worlds grow things the core worlds can't, giving
   settlements real leverage in trade negotiations
 - **Essence ranching** — positioning near generative hex zones and building
   waystation infrastructure to service the crews who work them
 
-The Alliance needs Rim output. They just prefer the Rim not to know that.
+The Collegium needs Rim output. They just prefer the Limes not to know that.
 
 ### Magic Items & The Secondary Market
-- **Alliance manufacture:** Common/uncommon, reliable, available at standard
-  Essence price from any Alliance-affiliated station
-- **Pre-Calamity originals:** Items the Alliance has never catalogued. Some do
-  things Alliance manufacture can't replicate. Meridian recognizes some of them
+- **Collegium manufacture:** Common/uncommon, reliable, available at standard
+  Essence price from any Collegium-affiliated station
+- **Pre-Calamity originals:** Items the Collegium has never catalogued. Some do
+  things Collegium manufacture can't replicate. Meridian recognizes some of them
   and doesn't always say so
 - **Rim craft:** Crude, unreliable, occasionally brilliant. May work perfectly,
   may work once, may work better than intended. Not priced in Essence — barter
 
-The extraction loop (revised): Rim crews find rare items → sell copy rights to
-Alliance for Essence bounty → keep the original → Alliance adds it to catalog →
-future Alliance forces may carry it. The Alliance pushes hard for rights sales.
+The extraction loop (revised): Limes crews find rare items → sell copy rights to
+Collegium for Essence bounty → keep the original → Collegium adds it to catalog →
+future Collegium forces may carry it. The Collegium pushes hard for rights sales.
 The crew decides how much of the pre-Calamity world they're willing to hand over.
 
 ---
@@ -335,7 +335,7 @@ What followed wasn't ideological civil war. It was a world full of people who we
 powerful yesterday and helpless today, all equally desperate, scrambling to control
 the few hundred surviving Vincula because they were the only path back to power.
 
-The Alliance won because they secured surviving Vincula fastest and rebuilt
+The Collegium won because they secured surviving Vincula fastest and rebuilt
 bond infrastructure first. They didn't win because they were righteous.
 They won because they moved quickly in a crisis and then turned that crisis
 into a permanent institutional advantage.
@@ -414,7 +414,7 @@ Three missions posted before each session. Each should have:
 **The three opening missions (Session Zero board):**
 
 **A — Belated (Low / Tier 1 / 5 Essence gross):** Welfare check on a farming outpost
-that missed transmissions. Void-touched pest problem in the basement. Alliance crew
+that missed transmissions. Void-touched pest problem in the basement. Collegium crew
 already on site with charter paperwork. Negotiation and combat both viable paths.
 
 **B — Last Transmission (Medium / Tier 1 / 8 Essence gross, tiered):** Recovery job.
@@ -437,15 +437,15 @@ is the content.
 
 The following are intentionally open. Do not invent details for these without
 explicit instruction:
-- Specific faction names beyond "the Alliance" and "the Rim"
+- Specific faction names beyond "the Collegium" and "the Limes"
 - Full hex map (geography is defined by missions as they're played)
 - Named NPCs beyond Rennick Osal and the *Constant*
-- Detailed Alliance hierarchy and internal politics
+- Detailed Collegium hierarchy and internal politics
 - The truth of the Calamity
 - Meridian's specific pre-Calamity history
 - Whether other spheres exist and what's in them
 - Mechanics of Essence use beyond level 20 (Ascendant Vinculum territory)
-- What the Alliance does with successfully catalogued rare items over time
+- What the Collegium does with successfully catalogued rare items over time
 
 ---
 

--- a/docs/WORLD_CONTEXT.md
+++ b/docs/WORLD_CONTEXT.md
@@ -7,6 +7,21 @@ Do not invent lore. Do not contradict this document. If something is undefined, 
 
 ---
 
+## The Pitch
+
+*For players, session zero, or anywhere a one-paragraph summary is needed:*
+
+> Join a sentient starship's crew on the edge of known space. Every week, vote on which
+> mission you run — safe nearby jobs or dangerous far-out heists. You level up with
+> everyone else, magic items you find are yours to keep, and your choices actually shape
+> what happens next. Bring any character you want, play one-shots, die if you're not
+> careful. First mission next week — come see what this ship wants from you.
+
+The mechanical pitch: space Western heists with a cool ship. Level up with your crew.
+Your choices matter. Accessible enough that your group actually shows up to play.
+
+---
+
 ## The Setting
 
 A single crystal sphere containing dozens of worlds (hex map). Travel between worlds
@@ -148,6 +163,19 @@ Net Essence per 3-mission cycle at the target rest rate (one long rest per three
 missions): **10 / 20 / 30 / 40** by tier. Scales linearly because mission income
 and rest cost both double each tier.
 
+**Ship support:** A sworn character can describe any class ability as being channeled
+through Meridian's systems — a warlock's eldritch blast becomes a turret volley, a
+ranger's hunter's mark routes through targeting overlays. If the GM rules the
+narrative fits, the character gets one of two bonuses:
+- **Weapon/attack abilities:** doubled damage dice
+- **Defensive/utility abilities:** proficiency added to a relevant saving throw (if
+  not already proficient) or advantage on a relevant check
+
+This is adjudicated per-use at the table, not a standing feature. The GM should
+approve or deny based on whether the fiction actually connects the ability to the ship.
+Meridian's voice in these moments is dry and functional: *"Targeting system online.
+Try not to waste the shot."*
+
 **Magic items:** The Alliance manufactures and sells common and uncommon items
 from their standard catalog. Rare and legendary items exist only in pre-Calamity
 derelicts — the Alliance has never reverse-engineered one. Essence is the de facto
@@ -156,6 +184,20 @@ currency between Rim crews and Alliance traders.
 Common and uncommon items are purchased outright. Rare and above are recovered from
 derelicts and require Meridian to spend Essence integrating them — restoring
 dormant systems, re-binding arcane patterns, making them usable by mortal crew.
+
+**Equip vs. attune to ship:** Every magic item the crew acquires has two possible
+fates:
+- **Equip to a character** — normal attunement. The character carries and uses the
+  item. It leaves with the character if they die or rotate out.
+- **Attune to the ship** — the item is integrated into Meridian's hull. It provides
+  a persistent, campaign-level benefit that applies to all sworn crew. It does not
+  leave with any individual character. Meridian absorbs it; it's part of her now.
+
+The choice is permanent once made. Ship-attuned items should provide benefits that
+make sense as shipwide systems — navigation, life support, hull reinforcement,
+communications — rather than personal combat bonuses. The GM determines the specific
+persistent benefit when the item is integrated. This decision is always visible in
+the ledger.
 
 | Rarity | Full cost | Alliance copy rights | Net after rights sale |
 |---|---|---|---|
@@ -317,6 +359,11 @@ This is an open-table campaign. Variable attendance is a feature, not a problem.
 - Session results update the ledger immediately and permanently
 - New characters enter at Meridian's current crew level — no level 1 punishment
 - Dead characters are replaced quickly — the ship continues, crew rotates
+
+**Starting level:** The campaign begins at level 3. Meridian's reserves open at the
+level 3 threshold (10 Essence). New players never enter below level 3 regardless of
+when they join. The first few missions exist to push the crew toward level 4 — players
+discover how the economy works before the stakes compound.
 
 **The crew model:** Characters are temporary. Meridian is permanent.
 The campaign's continuity lives in the ship's ledger, not in any individual character.

--- a/e2e/screenshot.mjs
+++ b/e2e/screenshot.mjs
@@ -20,7 +20,7 @@ async function getToken(role) {
       username: role === 'admin' ? 'Screenshot Admin' : 'Screenshot Player',
       role,
       campaign_guild_id: 'screenshot-guild-001',
-      campaign_name: 'The Inheritors',
+      campaign_name: 'Meridian Crew',
     }),
   });
   const data = await r.json();

--- a/frontend/src/lib/components/HexGrid.svelte
+++ b/frontend/src/lib/components/HexGrid.svelte
@@ -130,16 +130,13 @@
 			<div class="flex flex-col gap-1">
 				<div class="flex items-center gap-2">
 					<span class="inline-block h-3 w-3 rounded-sm" style="background:rgba(59,130,246,0.5)"></span>
-					<span>Kathedral League</span>
+					<span>Collegium</span>
 				</div>
 				<div class="flex items-center gap-2">
 					<span class="inline-block h-3 w-3 rounded-sm" style="background:rgba(245,158,11,0.5)"></span>
-					<span>Vastarei</span>
+					<span>Limes</span>
 				</div>
 				<div class="flex items-center gap-2">
-					<span class="inline-block h-3 w-3 rounded-sm" style="background:rgba(34,197,94,0.4)"></span>
-					<span>Inheritors</span>
-				</div>
 				<div class="mt-1 border-t border-base-content/10 pt-1 flex flex-col gap-1 opacity-70">
 					<span>⚑ Claimed &amp; Developed (0.5h)</span>
 					<span>≡ Friendly Controlled (1h)</span>

--- a/frontend/src/lib/components/HexGrid.svelte
+++ b/frontend/src/lib/components/HexGrid.svelte
@@ -136,7 +136,6 @@
 					<span class="inline-block h-3 w-3 rounded-sm" style="background:rgba(245,158,11,0.5)"></span>
 					<span>Limes</span>
 				</div>
-				<div class="flex items-center gap-2">
 				<div class="mt-1 border-t border-base-content/10 pt-1 flex flex-col gap-1 opacity-70">
 					<span>⚑ Claimed &amp; Developed (0.5h)</span>
 					<span>≡ Friendly Controlled (1h)</span>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -74,8 +74,7 @@ export interface LedgerEntry {
 export interface CharacterStats {
     id: number;
     character_id: number;
-    xp: number;
-    scrip: number;
+    gold: number;
 }
 
 export interface Item {
@@ -117,8 +116,7 @@ export interface Mission {
 export interface MissionReward {
     id: number;
     item_id?: number;
-    xp?: number;
-    scrip?: number;
+    gold?: number;
     item?: Item;
 }
 

--- a/frontend/src/lib/utils/terrainColors.ts
+++ b/frontend/src/lib/utils/terrainColors.ts
@@ -19,12 +19,10 @@ export function getTerrainColor(terrain: string): string {
 
 export function getFactionBadgeStyle(faction: string | null): string {
 	switch (faction) {
-		case 'Kathedral':
+		case 'Collegium':
 			return 'background:rgba(59,130,246,0.2);border-color:rgba(59,130,246,0.4)';
-		case 'Vastarei':
+		case 'Limes':
 			return 'background:rgba(245,158,11,0.2);border-color:rgba(245,158,11,0.4)';
-		case 'Inheritors':
-			return 'background:rgba(34,197,94,0.2);border-color:rgba(34,197,94,0.4)';
 		default:
 			return '';
 	}

--- a/frontend/src/routes/store/+page.svelte
+++ b/frontend/src/routes/store/+page.svelte
@@ -2,12 +2,11 @@
 	import { onMount } from 'svelte';
 	import { auth } from '$lib/auth';
 	import { api } from '$lib/api';
-	import type { StoreItem, Character } from '$lib/types';
+	import type { StoreItem } from '$lib/types';
 	import LoadingSpinner from '$lib/components/LoadingSpinner.svelte';
 	import Modal from '$lib/components/Modal.svelte';
 
 	let storeItems: StoreItem[] = [];
-	let character: Character | null = null;
 	let loading = true;
 	let error = '';
 	let successMessage = '';
@@ -16,26 +15,18 @@
 	let purchaseQuantity = 1;
 	let showPurchaseConfirm = false;
 
-	$: activeCharacterId = $auth.user?.active_character?.id;
+	$: activeCharacter = $auth.user?.active_character;
+	$: activeCharacterId = activeCharacter?.id;
+	$: characterGold = activeCharacter?.stats?.gold ?? 0;
 
-	// Fetch store items on mount
-	onMount(fetchStoreItems);
-
-	// Fetch character data whenever activeCharacterId changes (or initially)
-	$: if (activeCharacterId) {
-		fetchCharacter(activeCharacterId);
-	}
+	onMount(async () => {
+		await fetchStoreItems();
+	});
 
 	async function fetchStoreItems() {
-		try {
-			storeItems = await api('GET', '/store/items/');
-		} catch (e) {}
-	}
-
-	async function fetchCharacter(charId: number) {
 		loading = true;
 		try {
-			character = await api('GET', `/characters/${charId}`);
+			storeItems = await api('GET', '/store/items/');
 		} catch (e) {
 		} finally {
 			loading = false;
@@ -49,14 +40,14 @@
 	}
 
 	async function handlePurchase() {
-		if (!selectedItem || !character) return;
+		if (!selectedItem || !activeCharacterId) return;
 		error = '';
 		successMessage = '';
 		try {
 			await api('POST', `/store/items/${selectedItem.id}/purchase?quantity=${purchaseQuantity}`);
 			successMessage = `Successfully purchased ${purchaseQuantity}x ${selectedItem.item.name}!`;
 			showPurchaseConfirm = false;
-			await Promise.all([fetchStoreItems(), fetchCharacter(character.id)]);
+			await fetchStoreItems();
 			setTimeout(() => (successMessage = ''), 5000);
 		} catch (e) {
 			error = e instanceof Error ? e.message : 'Purchase failed.';
@@ -71,16 +62,16 @@
 		<div>
 			<h1 class="text-4xl font-[var(--font-cinzel)] font-bold text-primary">Company Store</h1>
 			<p class="text-sm text-base-content/65">
-				Trade your hard-earned Scrip for valuable equipment.
+				Acquire equipment and supplies. Prices in GP.
 			</p>
 		</div>
 
-		{#if character}
+		{#if activeCharacter}
 			<div class="stats border border-primary/20 bg-base-200 shadow">
 				<div class="stat px-4 py-2">
-					<div class="stat-title text-[10px] font-bold text-primary uppercase">Your Balance</div>
+					<div class="stat-title text-[10px] font-bold text-primary uppercase">Your Gold</div>
 					<div class="stat-value text-2xl text-primary">
-						{character.stats.scrip} <span class="text-xs">Scrip</span>
+						{characterGold} <span class="text-xs">GP</span>
 					</div>
 				</div>
 			</div>
@@ -143,7 +134,7 @@
 					<div class="card-body">
 						<div class="mb-2 flex items-start justify-between">
 							<h2 class="card-title text-xl font-bold">{item.item.name}</h2>
-							<div class="badge font-bold badge-primary">{item.price} Scrip</div>
+							<div class="badge font-bold badge-primary">{item.price} GP</div>
 						</div>
 
 						<p class="mb-4 line-clamp-2 h-12 text-sm text-base-content/70">
@@ -162,8 +153,7 @@
 							<div class="card-actions">
 								<button
 									class="btn btn-sm btn-primary"
-									disabled={item.quantity_available <= 0 ||
-										(character && character.stats.scrip < item.price)}
+									disabled={item.quantity_available <= 0 || !activeCharacterId}
 									on:click={() => openPurchaseModal(item)}
 								>
 									Purchase
@@ -193,7 +183,7 @@
 				<label class="label">
 					<span class="label-text">How many?</span>
 					<span class="label-text-alt text-base-content/65"
-						>Total Price: {selectedItem.price * purchaseQuantity} Scrip</span
+						>Total Cost: {selectedItem.price * purchaseQuantity} GP</span
 					>
 				</label>
 				<div class="flex items-center gap-2">
@@ -219,8 +209,8 @@
 				</div>
 			</div>
 
-			{#if character && character.stats.scrip < selectedItem.price * purchaseQuantity}
-				<p class="animate-pulse text-sm font-bold text-warning">Insufficient Scrip!</p>
+			{#if characterGold < selectedItem.price * purchaseQuantity}
+				<p class="animate-pulse text-sm font-bold text-warning">Not enough gold.</p>
 			{/if}
 		</div>
 	{/if}
@@ -229,9 +219,7 @@
 		<button class="btn btn-ghost" on:click={() => (showPurchaseConfirm = false)}>Cancel</button>
 		<button
 			class="btn btn-primary"
-			disabled={!selectedItem ||
-				!character ||
-				character.stats.scrip < selectedItem.price * purchaseQuantity}
+			disabled={!selectedItem || !activeCharacterId || characterGold < (selectedItem?.price ?? 0) * purchaseQuantity}
 			on:click={handlePurchase}
 		>
 			Confirm

--- a/frontend/src/tests/dashboard.test.ts
+++ b/frontend/src/tests/dashboard.test.ts
@@ -11,13 +11,13 @@ const mockShip = {
 };
 
 const mockSession = {
-    id: 1, name: 'Into the Substrata', description: 'Deep run.',
+    id: 1, name: 'Into the Dark Reach', description: 'Deep run.',
     session_date: new Date(Date.now() + 86400000 * 3).toISOString(),
     status: 'Open', min_players: 4, max_players: 6, players: [],
     proposals: [{
         id: 10, session_id: 1, mission_id: 5, proposed_by_id: 2,
         status: 'proposed',
-        mission: { id: 5, name: 'The Bone Market', tier: 'Tier 1', region: 'Substrata', description: null,
+        mission: { id: 5, name: 'The Bone Market', tier: 'Tier 1', region: 'Outer Rim', description: null,
             status: 'active', cooldown_days: 7, is_retired: false, is_discoverable: true,
             last_run_date: null, rewards: [], players: [] },
         backers: [{ id: 2, name: 'Vesper', description: null, image_url: null, owner_id: 99 }],
@@ -25,10 +25,10 @@ const mockSession = {
 };
 
 const mockMissions = [
-    { id: 5, name: 'The Bone Market', tier: 'Tier 1', region: 'Substrata', description: 'A grim place.',
+    { id: 5, name: 'The Bone Market', tier: 'Tier 1', region: 'Outer Rim', description: 'A grim place.',
       status: 'active', cooldown_days: 7, is_retired: false, is_discoverable: true,
       last_run_date: null, rewards: [], players: [] },
-    { id: 6, name: 'The Pale Gate', tier: 'Tier 2', region: 'Cathedral', description: null,
+    { id: 6, name: 'The Pale Gate', tier: 'Tier 2', region: 'Core Approach', description: null,
       status: 'active', cooldown_days: 14, is_retired: false, is_discoverable: true,
       last_run_date: null, rewards: [], players: [] },
 ];
@@ -54,12 +54,12 @@ vi.mock('$lib/auth', () => ({
                     active_character: {
                         id: 7, name: 'Cassia Vell', class_name: 'Rogue', level: 3,
                         status: 'Active', missions_completed: 5, owner_id: 1,
-                        stats: { id: 1, character_id: 7, xp: 0, scrip: 10 },
+                        stats: { id: 1, character_id: 7 },
                         inventory: [], missions: [], game_sessions: [],
                     },
                     characters: [],
                 },
-                campaign: { id: 1, name: 'The Inheritors' },
+                campaign: { id: 1, name: 'Meridian Crew' },
             });
             return () => {};
         },
@@ -89,8 +89,7 @@ describe('Dashboard', () => {
 
     test('shows upcoming session with its proposal', async () => {
         render(Dashboard);
-        await waitFor(() => expect(screen.getByText('Into the Substrata')).toBeInTheDocument());
-        // 'The Bone Market' appears in the proposal list and the missions section
+        await waitFor(() => expect(screen.getByText('Into the Dark Reach')).toBeInTheDocument());
         expect(screen.getAllByText('The Bone Market').length).toBeGreaterThanOrEqual(1);
     });
 


### PR DESCRIPTION
## Summary

- **World context & PRD rewritten** to match the space western pitch: single Essence economy for the ship, GP (gold) for per-character purchases, starting level 3, ship-support ability flavoring, equip-vs-attune distinction
- **Faction rename**: The Alliance → Collegium, The Rim → Limes (etymologically consistent with Vinculum/Meridian register); seed data, DB migration, schema literals, UI legend, and oneshot prompt all updated
- **`scrip`/`xp` → `gold`** across the full stack: `character_stats`, `mission_rewards` models, schemas, service logic, tests, store page UI, and seed script; migrations `0003` and `0004` cover the DDL changes

## Test plan

- [x] Backend: 151 passed, 2 skipped
- [x] Frontend unit: 12 passed
- [ ] E2E: requires running pod — smoke/player/admin specs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)