### PR TITLE
fix: Read Pydantic settings within Auth route endpoints to correctly fetch Discord env secrets in Cloud Run

### DIFF
--- a/backend/app/modules/auth/router.py
+++ b/backend/app/modules/auth/router.py
@@ -15,7 +15,6 @@ from ..campaigns import service as campaign_service
 logger = logging.getLogger("app.auth")
 
 router = APIRouter()
-settings = get_settings()
 
 import base64
 import json
@@ -24,6 +23,7 @@ import json
 async def login_via_discord(
     return_to: Optional[str] = None,
 ):
+    settings = get_settings()
     """
     Redirects the user to Discord OAuth2 login page.
     Optionally accepts a 'return_to' query param to redirect back to a specific frontend URL (e.g. Vercel preview).
@@ -141,6 +141,7 @@ async def discord_proxy_callback(code: str, state: str):
 
 @router.get("/discord/callback", tags=["Authentication"])
 async def discord_callback(code: str, request: Request, response: Response, state: Optional[str] = None, db: Session = Depends(get_db)):
+    settings = get_settings()
     """
     Handles the callback from Discord, exchanges code for token, and gets user info.
     Returns a temporary token that allows the user to list/select campaigns.
@@ -275,6 +276,7 @@ async def dev_token(
     request: DevTokenRequest,
     db: Session = Depends(get_db),
 ):
+    settings = get_settings()
     """
     Dev-only endpoint for e2e testing. Returns a valid campaign-scoped JWT,
     creating the campaign and user in the database if they don't exist.


### PR DESCRIPTION
Resolves an issue where `DISCORD_CLIENT_ID` would be parsed as an empty string because `get_settings()` was called at the global module level during application load instead of inside the route handlers where environment variables injected by Google Cloud Run `gcloud deploy --set-env-vars` are correctly evaluated.

---
*PR created automatically by Jules for task [12228158643667835213](https://jules.google.com/task/12228158643667835213) started by @bahaynes*