### PR TITLE
fix: Allow Teardown workflow to continue if Neon branch doesn't exist

### DIFF
--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Delete Neon Branch
         uses: neondatabase/delete-branch-action@v3
+        continue-on-error: true
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
           branch: preview/pr-${{ github.event.number }}-${{ steps.branch_name.outputs.current_branch }}


### PR DESCRIPTION
The `neondatabase/delete-branch-action@v3` step was failing with `ERROR: Branch preview/... not found` because Neon auto-cleans or reclaims resources. We added `continue-on-error: true` so the Teardown workflow can succeed even if the Neon branch is already deleted.

---
*PR created automatically by Jules for task [11423174303849897937](https://jules.google.com/task/11423174303849897937) started by @bahaynes*