### PR TITLE
fix: correctly pass environment variables in Cloud Run deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,16 +119,7 @@ jobs:
             --project ${{ env.PROJECT_ID }} \
             --allow-unauthenticated \
             --port 10000 \
-            --set-env-vars="MODE=prod" \
-            --set-env-vars="APP_ENV=${{ env.APP_ENV }}" \
-            --set-env-vars="DATABASE_URL=${{ env.DATABASE_URL }}" \
-            --set-env-vars="DISCORD_CLIENT_ID=${{ secrets.DISCORD_CLIENT_ID }}" \
-            --set-env-vars="DISCORD_CLIENT_SECRET=${{ secrets.DISCORD_CLIENT_SECRET }}" \
-            --set-env-vars="DISCORD_BOT_TOKEN=${{ secrets.DISCORD_BOT_TOKEN }}" \
-            --set-env-vars="ADMIN_DISCORD_IDS=${{ secrets.ADMIN_DISCORD_IDS }}" \
-            --set-env-vars="LLM_API_KEY=${{ secrets.LLM_API_KEY }}" \
-            --set-env-vars="DISCORD_REDIRECT_URI=${{ env.DISCORD_REDIRECT_URI }}" \
-            --set-env-vars="FRONTEND_URL=https://dnd-frontend${{ env.SERVICE_SUFFIX }}-placeholder.run.app" \
+            --set-env-vars="^|^MODE=prod|APP_ENV=${{ env.APP_ENV }}|DATABASE_URL=${{ env.DATABASE_URL }}|DISCORD_CLIENT_ID=${{ secrets.DISCORD_CLIENT_ID }}|DISCORD_CLIENT_SECRET=${{ secrets.DISCORD_CLIENT_SECRET }}|DISCORD_BOT_TOKEN=${{ secrets.DISCORD_BOT_TOKEN }}|ADMIN_DISCORD_IDS=${{ secrets.ADMIN_DISCORD_IDS }}|LLM_API_KEY=${{ secrets.LLM_API_KEY }}|DISCORD_REDIRECT_URI=${{ env.DISCORD_REDIRECT_URI }}|FRONTEND_URL=https://dnd-frontend${{ env.SERVICE_SUFFIX }}-placeholder.run.app" \
             --format="value(status.url)" > backend_url.txt
 
           BACKEND_URL=$(cat backend_url.txt)
@@ -190,7 +181,7 @@ jobs:
           gcloud run services update dnd-backend${{ env.SERVICE_SUFFIX }} \
             --region ${{ env.REGION }} \
             --project ${{ env.PROJECT_ID }} \
-            --set-env-vars="FRONTEND_URL=${{ env.FRONTEND_URL }}"
+            --update-env-vars="FRONTEND_URL=${{ env.FRONTEND_URL }}"
 
       - name: Comment on PR
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
This PR resolves an issue in the Google Cloud Run deployment pipeline where environment variables, including `DISCORD_CLIENT_ID` and `DATABASE_URL`, were being unset during the initial deployment and subsequent backend service update.

The fixes are:
1. Changed `gcloud run services update` to use `--update-env-vars` instead of `--set-env-vars` when setting the `FRONTEND_URL` environment variable. `--set-env-vars` completely overwrote all previously configured environment variables, destroying all credentials.
2. In the initial `gcloud run deploy dnd-backend` step, unified the multiple `--set-env-vars` into a single, comprehensive string using the `^|^` delimiter pattern. Passing multiple `--set-env-vars` flags usually results in only the last flag executing. Furthermore, some variables like `ADMIN_DISCORD_IDS` contain commas, which break the standard `--set-env-vars` format. The delimiter resolves this issue cleanly.

This resolves the Discord API error `Value "" is not snowflake` that users encountered upon login by ensuring credentials are properly retained inside the Cloud Run container.

---
*PR created automatically by Jules for task [13262916597284071395](https://jules.google.com/task/13262916597284071395) started by @bahaynes*