### PR TITLE
fix(deploy): Add missing database migrations step for production push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,6 +125,14 @@ jobs:
           echo "DATABASE_URL=$DB_URL" >> $GITHUB_ENV
           echo "DISCORD_REDIRECT_URI=https://westmarches.bahaynes.com/api/auth/discord/callback" >> $GITHUB_ENV
 
+      - name: Run Alembic Migrations (Production)
+        if: github.event_name == 'push'
+        working-directory: backend
+        run: |
+          pip install uv
+          uv sync --group dev
+          uv run alembic upgrade head
+
       - name: Build and Push Backend
         run: |
           IMAGE_TAG=${{ env.IMAGE_PREFIX }}/dnd-backend:${{ github.sha }}


### PR DESCRIPTION
This PR fixes an "Error setting up campaign" issue that occurs in production because the `campaigns` table (and other tables) did not exist.

The underlying cause was that the `.github/workflows/deploy.yml` file only executed `alembic upgrade head` for pull requests and not for the main branch push event that deploys to production. 

This PR adds an equivalent `Run Alembic Migrations (Production)` step for the `push` event to ensure migrations are run correctly against the production Neon database.

---
*PR created automatically by Jules for task [9591943722271569739](https://jules.google.com/task/9591943722271569739) started by @bahaynes*